### PR TITLE
Fix broken discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > Before reporting a bug please check the [known issues](https://contracts.polkadot.io/known_issues/).
-> Please **don't** open issues for support question. Instead, go to [our Discord](https://discord.gg/bKza3GEBEA) for that.
+> Please **don't** open issues for support question. Instead, [get in touch](https://contracts.polkadot.io/#get-in-touch) with us for that.
 
 # Contracts on AssetHub Bug Tracker
 


### PR DESCRIPTION
Point to our documentation section, instead.

Fixes #43 